### PR TITLE
Allow all salts to be used with the NuclearCraft Melter

### DIFF
--- a/scripts/NuclearCraft.zs
+++ b/scripts/NuclearCraft.zs
@@ -141,3 +141,17 @@ scripts.process.electrolyze(<fluid:koh>                *666,  [<fluid:potassium>
 scripts.process.electrolyze(<fluid:alumina>            *144,  [<fluid:aluminum>   *288, <fluid:oxygen>    *3000], "except: NCElectrolyzer");
 scripts.process.electrolyze(<fluid:heavywater>         *1000, [<fluid:deuterium>  *1000, <fluid:tritium>  *50, <fluid:oxygen>*500], "except: NCElectrolyzer");
 scripts.process.electrolyze(<fluid:ic2heavy_water>     *1000, [<fluid:deuterium>  *1000, <fluid:tritium>  *50, <fluid:oxygen>*500], "except: NCElectrolyzer");
+
+# Add Animania/Immersive Tech Salt to Melter
+// mods.nuclearcraft.melter.removeRecipeWithInput([itemInput]);
+// mods.nuclearcraft.melter.removeRecipeWithOutput([fluidOutput]);
+// mods.nuclearcraft.melter.removeAllRecipes();
+// mods.nuclearcraft.melter.addRecipe([itemInput, fluidOutput, @Optional double timeMultiplier, @Optional double powerMultiplier, @Optional double processRadiation]);
+
+mods.nuclearcraft.melter.removeRecipeWithInput(<mekanism:salt>);
+mods.nuclearcraft.melter.removeRecipeWithInput(<harvestcraft:saltitem>);
+
+var allSalts = <immersivetech:material> | <animania:salt> | <mekanism:salt> | <harvestcraft:saltitem>;
+
+//mods.nuclearcraft.melter.addRecipe([<ore:dustSalt>,<liquid:brine> * 15, 0.25, 0.5]);
+mods.nuclearcraft.melter.addRecipe([allSalts,<liquid:brine> * 15, 0.25, 0.5]);


### PR DESCRIPTION
This thing just refuses to work properly with oreDict. Also adds Immersive Tech salt.
Fixes #1946