### PR TITLE
blacklist additions

### DIFF
--- a/config/solcarrot.cfg
+++ b/config/solcarrot.cfg
@@ -12,7 +12,7 @@ general {
 
     # Foods in this list won't affect the player's health nor show up in the food book.
     S:"Food Blacklist" <
-        actuallyadditions:item_food:18 
+        actuallyadditions:item_food:18
         tconstruct:edible:5
         animus:bloodapple
         tcomplement:edibles:10

--- a/config/solcarrot.cfg
+++ b/config/solcarrot.cfg
@@ -12,9 +12,11 @@ general {
 
     # Foods in this list won't affect the player's health nor show up in the food book.
     S:"Food Blacklist" <
-        actuallyadditions:item_food:18
+        actuallyadditions:item_food:18 
         tconstruct:edible:5
         animus:bloodapple
+        tcomplement:edibles:10
+        harvestcraft:carrotcakeitem
      >
 
     # When this list contains anything, the blacklist is ignored and instead only foods from here count.


### PR DESCRIPTION
This would add two items to the blacklist: carrot cake, which doesn't get added even when eaten (despite other similar cake-like items working just fine), and milk chocolate ingots, which aren't obtainable. 

I was unable to find any mentions of the carrot cake not working with spice of life. As far as milk chocolate ingots though, there was this one post here: https://github.com/EnigmaticaModpacks/Enigmatica2Expert/issues/1812
While it makes sense that one would be uninterested in taking the effort to remove the crafting recipe, adding it to the blacklist would be a really quick and easy fix.