### PR TITLE
Blacklist AS from Sack of Holding

### DIFF
--- a/config/cyclicmagic.cfg
+++ b/config/cyclicmagic.cfg
@@ -2369,6 +2369,7 @@ modpacks {
     S:SackHoldingBlacklist <
         environmentaltech:*
         ic2:*
+        astralsorcery:*
      >
 
     # Crops & leaves that are blocked from harvesting (Brush Scythe and Tree Scythe). A star is for a wildcard  [default: [terraqueous:pergola], [harvestcraft:*_sapling]]


### PR DESCRIPTION
I swear we already did this at some point, and if we didn't, I don't know why we haven't.
To stop people moving generated AS Crystals