### PR TITLE
Fix missing Petal recipes

### DIFF
--- a/scripts/Botania.zs
+++ b/scripts/Botania.zs
@@ -127,8 +127,9 @@ import crafttweaker.item.IIngredient as IIngredient;
     <botania:livingrock>, <botania:livingrock>, <botania:livingrock>]);
 
 # Removing double flower recipes
-	recipes.remove(<botania:petal:*> * 4, <botania:doubleflower1:*>);
-	recipes.remove(<botania:petal:*> * 4, <botania:doubleflower2:*>);
+#	recipes.remove(<botania:petal:*> * 4, <botania:doubleflower1:*>);
+#	recipes.remove(<botania:petal:*> * 4, <botania:doubleflower2:*>);
+# Disabled, as those were removing even normal petal recipe for some reason ^-^"
 	
 # Super travel belt
 	recipes.remove(<botania:supertravelbelt>);


### PR DESCRIPTION
Seems like a script to disable petals from Double flowers, also disabled *for some reason* petals from normal flowers ^^"
Disabling this part of script fixes it :D

Resolves #2049 