### PR TITLE
Steam Turbine adjustments

### DIFF
--- a/config/mctimmersivetechnology.cfg
+++ b/config/mctimmersivetechnology.cfg
@@ -74,7 +74,7 @@ general {
             B:register_solarTower_recipes=true
 
             # Should default Steam Turbine recipes be registered ? [Default=true]
-            B:register_steamTurbine_recipes=true
+            B:register_steamTurbine_recipes=false
         }
 
         alternator {
@@ -82,7 +82,7 @@ general {
             I:alternator_energy_capacitorSize=1200000
 
             # Energy production when running at maximum speed and torque [Default=12288]
-            I:alternator_energy_perTick=12288
+            I:alternator_energy_perTick=98304
 
             # Alternator sound based RPM or Capacity [Default=true]
             B:alternator_sound_RPM=true

--- a/scripts/ImmersiveTech.zs
+++ b/scripts/ImmersiveTech.zs
@@ -1,0 +1,6 @@
+import mods.immersivetechnology.SteamTurbine;
+
+#Steam Turbine steam consumption
+# mods.immersivetechnology.SteamTurbine.addFuel(ILiquidStack output, ILiquidStack input, int time);
+
+SteamTurbine.addFuel(<liquid:water> * 4000, <liquid:steam> * 4000, 1);


### PR DESCRIPTION
This should fix #2061 . I tested it in my world and server and it was working as expected. Steam turbine now consumes 4 B/t of steam and produces 98304 rf/t like before the switch to the other fork of immersive tech.