### PR TITLE
Energy Balancing

### DIFF
--- a/config/environmentaltech/main.cfg
+++ b/config/environmentaltech/main.cfg
@@ -105,49 +105,49 @@ environmentaltech {
 
         solar_array {
             # Litherite Solar Cell efficiency [range: 48 ~ 480, default: 48]
-            I:1litherite_solar_cell_efficiency=100
+            I:1litherite_solar_cell_efficiency=85
 
             # Erodium Solar Cell efficiency [range: 64 ~ 640, default: 64]
-            I:2erodium_solar_cell_efficiency=125
+            I:2erodium_solar_cell_efficiency=100
 
             # Kyronite Solar Cell efficiency [range: 96 ~ 960, default: 96]
-            I:3kyronite_solar_cell_efficiency=130
+            I:3kyronite_solar_cell_efficiency=115
 
             # Pladium Solar Cell efficiency [range: 128 ~ 1280, default: 128]
-            I:4pladium_solar_cell_efficiency=232
+            I:4pladium_solar_cell_efficiency=130
 
             # Ionite Solar Cell efficiency [range: 192 ~ 1920, default: 192]
-            I:5ionite_solar_cell_efficiency=465
+            I:5ionite_solar_cell_efficiency=145
 
             # Aethium Solar Cell efficiency [range: 256 ~ 2560, default: 256]
-            I:6aethium_solar_cell_efficiency=4768
+            I:6aethium_solar_cell_efficiency=435
 
             # Is Module Enabled? [default: true]
             B:enabled=true
 
             # The power used to calculate increase in generation for each solar tier [range: 1.8 ~ 3.0, default: 2.0]
-            D:s_production_power=2.0
+            D:s_production_power=3.0
 
             # Base production rate if solar was running at 100% efficiency. [range: 64 ~ 256, default: 128]
             I:s_production_rate=128
 
             # Tier 1 Solar Array max efficiency percentage. [range: 100 ~ 1000, default: 100]
-            I:tier_1_solar_array_max_efficiency=1000
+            I:tier_1_solar_array_max_efficiency=200
 
             # Tier 2 Solar Array max efficiency percentage. [range: 200 ~ 2000, default: 200]
-            I:tier_2_solar_array_max_efficiency=1500
+            I:tier_2_solar_array_max_efficiency=250
 
             # Tier 3 Solar Array max efficiency percentage. [range: 400 ~ 4000, default: 400]
-            I:tier_3_solar_array_max_efficiency=2000
+            I:tier_3_solar_array_max_efficiency=300
 
             # Tier 4 Solar Array max efficiency percentage. [range: 800 ~ 8000, default: 800]
-            I:tier_4_solar_array_max_efficiency=2500
+            I:tier_4_solar_array_max_efficiency=350
 
             # Tier 5 Solar Array max efficiency percentage. [range: 1600 ~ 16000, default: 1600]
-            I:tier_5_solar_array_max_efficiency=4036
+            I:tier_5_solar_array_max_efficiency=400
 
             # Tier 6 Solar Array max efficiency percentage. [range: 3200 ~ 32000, default: 3200]
-            I:tier_6_solar_array_max_efficiency=5000
+            I:tier_6_solar_array_max_efficiency=450
         }
 
         thermal_electric_generator {

--- a/config/environmentaltech/main.cfg
+++ b/config/environmentaltech/main.cfg
@@ -111,7 +111,7 @@ environmentaltech {
             I:2erodium_solar_cell_efficiency=125
 
             # Kyronite Solar Cell efficiency [range: 96 ~ 960, default: 96]
-            I:3kyronite_solar_cell_efficiency=128
+            I:3kyronite_solar_cell_efficiency=130
 
             # Pladium Solar Cell efficiency [range: 128 ~ 1280, default: 128]
             I:4pladium_solar_cell_efficiency=232
@@ -120,13 +120,13 @@ environmentaltech {
             I:5ionite_solar_cell_efficiency=465
 
             # Aethium Solar Cell efficiency [range: 256 ~ 2560, default: 256]
-            I:6aethium_solar_cell_efficiency=1337
+            I:6aethium_solar_cell_efficiency=4768
 
             # Is Module Enabled? [default: true]
             B:enabled=true
 
             # The power used to calculate increase in generation for each solar tier [range: 1.8 ~ 3.0, default: 2.0]
-            D:s_production_power=3.0
+            D:s_production_power=2.0
 
             # Base production rate if solar was running at 100% efficiency. [range: 64 ~ 256, default: 128]
             I:s_production_rate=128
@@ -135,19 +135,19 @@ environmentaltech {
             I:tier_1_solar_array_max_efficiency=1000
 
             # Tier 2 Solar Array max efficiency percentage. [range: 200 ~ 2000, default: 200]
-            I:tier_2_solar_array_max_efficiency=2000
+            I:tier_2_solar_array_max_efficiency=1500
 
             # Tier 3 Solar Array max efficiency percentage. [range: 400 ~ 4000, default: 400]
-            I:tier_3_solar_array_max_efficiency=1200
+            I:tier_3_solar_array_max_efficiency=2000
 
             # Tier 4 Solar Array max efficiency percentage. [range: 800 ~ 8000, default: 800]
-            I:tier_4_solar_array_max_efficiency=3200
+            I:tier_4_solar_array_max_efficiency=2500
 
             # Tier 5 Solar Array max efficiency percentage. [range: 1600 ~ 16000, default: 1600]
-            I:tier_5_solar_array_max_efficiency=6400
+            I:tier_5_solar_array_max_efficiency=4036
 
             # Tier 6 Solar Array max efficiency percentage. [range: 3200 ~ 32000, default: 3200]
-            I:tier_6_solar_array_max_efficiency=12800
+            I:tier_6_solar_array_max_efficiency=5000
         }
 
         thermal_electric_generator {

--- a/config/extendedcrafting.cfg
+++ b/config/extendedcrafting.cfg
@@ -89,7 +89,7 @@ quantum_compression {
     I:energy_capacity=10000000
 
     # How much FE/t the Quantum Compressor should use when crafting by default. [range: 0 ~ 2147483647, default: 5000]
-    I:energy_rate=1000000
+    I:energy_rate=500000
 
     # Should the Quantum Compressor render the result item above it? [default: true]
     B:render_item=true

--- a/config/mekanism.cfg
+++ b/config/mekanism.cfg
@@ -187,7 +187,7 @@ general {
     B:LogPackets=false
 
     # Maximum Joules per mB of Steam. Also affects Thermoelectric Boiler.
-    D:MaxEnergyPerSteam=100.0
+    D:MaxEnergyPerSteam=10.0
 
     # Flamethrower Gas Tank capacity in mB.
     I:MaxFlamethrowerGas=24000
@@ -304,7 +304,7 @@ generation {
     D:BioGeneration=300.0
 
     # Affects the Injection Rate, Max Temp, and Ignition Temp.
-    D:EnergyPerFusionFuel=1500000.0
+    D:EnergyPerFusionFuel=1000000.0
 
     # Amount of energy in Joules the Heat Generator produces per tick. (heatGenerationLava * heatGenerationLava) + heatGenerationNether
     D:HeatGeneration=150.0


### PR DESCRIPTION
Normalizing energy production to be close to 25M rf/t
Mekanism Turbine: Output reduced by 90%, now caps at 26.74M rf/t
Mekanism Fusion: Output reduced by 33%, now caps at 19.93M rf/t
Popular [Fusion+Turbine setup](https://imgur.com/a/D2nDvRx) can no longer be sustained at max efficiency. Turbine in setup caps at 21.4M rf/t, and Reactor at 4.9M rf/t.
Untouched: Rainbow Generator sits at 25M rf/t, plus tidbits from other generators.
Untouched: NC Fusion, max size D-T reactor makes up to ~26M rf/t
Quantum Compressor: Energy required reduced by 50%. You can still have all 39 Singularities crafting with a single power setup.
ET Solar Panels -again: Too powerful due to miscalculations, output reduced by up-to 70%