### PR TITLE
Re-enable Amulets file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ MakeModpackFiles.bat
 MakeModpackFiles.ps1
 config/AppliedEnergistics2/CustomRecipes.cfg
 config/AppliedEnergistics2/VersionChecker.cfg
-config/astralsorcery/amulet_enchantments.cfg
 config/brandon3055/contributors.json
 config/brandon3055/Custom Fusion Recipe Info.txt
 config/vanillafix.cfg

--- a/config/astralsorcery/amulet_enchantments.cfg
+++ b/config/astralsorcery/amulet_enchantments.cfg
@@ -1,0 +1,69 @@
+# Configuration file
+
+##########################################################################################################
+# data
+#--------------------------------------------------------------------------------------------------------#
+# Defines a whitelist of which enchantments can be rolled and buffed by the enchantment-amulet. The higher the weight, the more likely that roll is selected.Format: <enchantment-registry-name>:<weight>
+##########################################################################################################
+
+data {
+    #  [default: [minecraft:protection:10], [minecraft:fire_protection:5], [minecraft:feather_falling:5], [minecraft:blast_protection:2], [minecraft:projectile_protection:5], [minecraft:respiration:2], [minecraft:aqua_affinity:2], [minecraft:thorns:1], [minecraft:depth_strider:2], [minecraft:frost_walker:2], [minecraft:sharpness:10], [minecraft:smite:5], [minecraft:bane_of_arthropods:5], [minecraft:knockback:5], [minecraft:fire_aspect:2], [minecraft:looting:2], [minecraft:sweeping:2], [minecraft:efficiency:10], [minecraft:silk_touch:1], [minecraft:unbreaking:5], [minecraft:fortune:2], [minecraft:power:10], [minecraft:punch:2], [minecraft:flame:2], [minecraft:infinity:1], [minecraft:luck_of_the_sea:2], [minecraft:lure:2], [minecraft:mending:2], [draconicevolution:enchant_reaper:2], [extrautils2:xu.kaboomerang:10], [extrautils2:xu.zoomerang:10], [extrautils2:xu.burnerang:10], [extrautils2:xu.bladerang:10], [extrautils2:xu.boomereaperang:10], [randomthings:magnetic:1], [openblocks:explosive:2], [openblocks:last_stand:5], [openblocks:flim_flam:2], [advancedrocketry:spacebreathing:10], [endercore:autosmelt:2], [endercore:xpboost:5], [enderio:soulbound:1], [enderio:witherweapon:5], [enderio:witherarrow:5], [enderio:repellent:1], [bibliocraft:bibliocraft.deathcompassench:1], [bibliocraft:bibliocraft.readingench:5], [exnihilocreatio:sieve_efficiency:10], [exnihilocreatio:sieve_fortune:2], [exnihilocreatio:sieve_luck_of_the_sea:2], [cofhcore:holding:5], [cofhcore:insight:5], [cofhcore:leech:5], [cofhcore:multishot:5], [cofhcore:smashing:2], [cofhcore:smelting:2], [cofhcore:soulbound:5], [cofhcore:vorpal:2], [cyclicmagic:enchantment.autosmelt:2], [cyclicmagic:enchantment.beheading:1], [cyclicmagic:enchantment.launch:10], [cyclicmagic:enchantment.lifeleech:10], [cyclicmagic:enchantment.magnet:1], [cyclicmagic:enchantment.multishot:1], [cyclicmagic:enchantment.quickdraw:1], [cyclicmagic:enchantment.reach:1], [cyclicmagic:enchantment.venom:10], [cyclicmagic:enchantment.waterwalking:1], [cyclicmagic:enchantment.expboost:1], [astralsorcery:enchantment.as.nightvision:1], [astralsorcery:enchantment.as.smelting:1]]
+    S:data <
+        minecraft:protection:10
+        minecraft:fire_protection:5
+        minecraft:feather_falling:5
+        minecraft:blast_protection:2
+        minecraft:projectile_protection:5
+        minecraft:respiration:2
+        minecraft:aqua_affinity:2
+        minecraft:thorns:1
+        minecraft:depth_strider:2
+        minecraft:frost_walker:2
+        minecraft:sharpness:10
+        minecraft:smite:5
+        minecraft:bane_of_arthropods:5
+        minecraft:knockback:5
+        minecraft:fire_aspect:2
+        minecraft:looting:2
+        minecraft:sweeping:2
+        minecraft:efficiency:10
+        minecraft:silk_touch:1
+        minecraft:unbreaking:5
+        minecraft:fortune:2
+        minecraft:power:10
+        minecraft:punch:2
+        minecraft:flame:2
+        minecraft:infinity:1
+        minecraft:luck_of_the_sea:2
+        minecraft:lure:2
+        minecraft:mending:2
+        draconicevolution:enchant_reaper:2
+        openblocks:last_stand:5
+        randomthings:magnetic:1
+        endercore:autosmelt:2
+        endercore:xpboost:5
+        enderio:soulbound:1
+        cofhcore:holding:5
+        cofhcore:insight:5
+        cofhcore:leech:5
+        cofhcore:multishot:5
+        cofhcore:smelting:2
+        cofhcore:soulbound:5
+        cofhcore:vorpal:2
+        astralsorcery:enchantment.as.nightvision:1
+        astralsorcery:enchantment.as.smelting:1
+        cyclicmagic:enchantment.waterwalking:1
+        cyclicmagic:enchantment.reach:1
+        cyclicmagic:enchantment.expboost:5
+        cyclicmagic:enchantment.launch:10
+        cyclicmagic:enchantment.magnet:1
+        cyclicmagic:enchantment.venom:5
+        cyclicmagic:enchantment.lifeleech:5
+        cyclicmagic:enchantment.beheading:3
+        cyclicmagic:enchantment.quickdraw:3
+        cyclicmagic:enchantment.excavation:1
+        cyclicmagic:enchantment.multishot:1
+     >
+}
+
+


### PR DESCRIPTION
Unfortunately we need this file to remove all the useless enchants from the Amulet whitelist.

I know it rearranges the "Defaults list" every boot and marks it as a change, but we still need the file itself intact