### PR TITLE
remove emtpy ER entries

### DIFF
--- a/config/gendustry/overrides/recipes.cfg
+++ b/config/gendustry/overrides/recipes.cfg
@@ -196,8 +196,7 @@ recipes { // MISC
     mutagen: B:nuclearcraft:block_depleted_plutonium => 9000 mb
     mutagen: I:nuclearcraft:plutonium                => 300 mb 
     mutagen: I:ic2:nuclear                           => 200 mb
-    mutagen: I:OD:dustCyanite                        => 50 mb
-    mutagen: I:OD:dustBlutonium                      => 2000 mb
+    
 
     protein: I:porkchop => 500 mb
     protein: I:fish => 250 mb


### PR DESCRIPTION
Removed the now empty ER entries from Mutagen production list. Unsuccesfully tried to add depleted LEU-235 fuel. No idea how to make that happen.