### PR TITLE
1.90g

### DIFF
--- a/config/cyclicmagic.cfg
+++ b/config/cyclicmagic.cfg
@@ -188,7 +188,7 @@ cyclicmagic {
         B:FluidMilk=true
 
         #  Set false to delete - requires restart [default: true]
-        B:FluidPoison=true
+        B:FluidPoison=false
 
         # glowing_chorus Set false to delete - requires restart [default: true]
         B:"GlowingChorus(Food)"=false

--- a/scripts/Avaritia.zs
+++ b/scripts/Avaritia.zs
@@ -141,7 +141,7 @@ import mods.jei.JEI.removeAndHide as rh;
 	[null, null, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, null, null], 
 	[null, null, <ore:dustAstralStarmetal>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>, null, null], 
 	[null, null, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, null], 
-	[null, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:ingotCrystalMatrix>, <astralsorcery:itemshiftingstar>.withTag({astralsorcery:{}}), <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
+	[null, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:ingotCrystalMatrix>, <extendedcrafting:material:40>, <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, null], 

--- a/scripts/Endergy.zs
+++ b/scripts/Endergy.zs
@@ -82,9 +82,7 @@ print("--- loading Endergy.zs ---");
 	<astralsorcery:itemcraftingcomponent:2>, <extendedcrafting:material:40>, 
 	<astralsorcery:itemcraftingcomponent:4>, <astralsorcery:itemcoloredlens:6>, 
 	<bloodmagic:blood_rune:9>, <bloodmagic:blood_rune:10>, <bloodmagic:points_upgrade>,
-	<bloodmagic:slate:4>, <astralsorcery:itemcelestialcrystal>.anyDamage(),
-	#<thaumcraft:phial:1>.withTag({Aspects: [{amount: 10, key: "vitium"}]}), 
-	<thaumcraft:mechanism_complex>]);
+	<bloodmagic:slate:4>, <thaumcraft:mechanism_complex>]);
 	
 	
 # Blutonium Block // Melodic Block

--- a/scripts/Endergy.zs
+++ b/scripts/Endergy.zs
@@ -79,7 +79,7 @@ print("--- loading Endergy.zs ---");
 	mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:benitoite>, 100000000, 1000000, <botania:manaresource:5>, 
 	[<botania:manaresource:9>, <botania:manaresource:1>, <botania:manaresource:7>, 
 	<botania:pylon:1>, <botania:manaresource:2>, <botania:manaresource:8>, 
-	<astralsorcery:itemcraftingcomponent:2>, <astralsorcery:itemshiftingstar>, 
+	<astralsorcery:itemcraftingcomponent:2>, <extendedcrafting:material:40>, 
 	<astralsorcery:itemcraftingcomponent:4>, <astralsorcery:itemcoloredlens:6>, 
 	<bloodmagic:blood_rune:9>, <bloodmagic:blood_rune:10>, <bloodmagic:points_upgrade>,
 	<bloodmagic:slate:4>, <astralsorcery:itemcelestialcrystal>.anyDamage(),

--- a/scripts/ExtendedCrafting.zs
+++ b/scripts/ExtendedCrafting.zs
@@ -157,3 +157,7 @@ recipes.addShaped("ExtendedCrafting Automating table", <extendedcrafting:interfa
 	[<ore:ingotBlackIron>, <extendedcrafting:material:10>, <ore:ingotBlackIron>],
 	[<extendedcrafting:material:17>, <extendedcrafting:frame>, <extendedcrafting:material:17>],
 	[<ore:ingotBlackIron>, <extendedcrafting:material:2>, <ore:ingotBlackIron>]]);
+
+# Harder Ender Star
+mods.extendedcrafting.EnderCrafting.remove(<extendedcrafting:material:40>);
+mods.extendedcrafting.EnderCrafting.addShaped(<extendedcrafting:material:40>, [[<astralsorcery:itemcraftingcomponent:4>, <minecraft:ender_eye>, <astralsorcery:itemcraftingcomponent:4>], [<astralsorcery:itemcraftingcomponent:2>, <actuallyadditions:item_misc:19>, <astralsorcery:itemcraftingcomponent:2>], [<astralsorcery:itemcraftingcomponent:4>, <minecraft:ender_eye>, <astralsorcery:itemcraftingcomponent:4>]]);


### PR DESCRIPTION
Couple hotfixes, one fixing a crash, other fixing problematic recipes.
This is also the patch to introduce SIB to the pack.

Disable Cyclic fluid poison, to make BoPs the default one as it generates in world and causes crashes otherwise
Replace Shifting Star in a few recipes that could be uncraftable on servers with Ender Stars
Made Ender Stars a bit harder to craft, matching Shifting Star slightly