### PR TITLE
Shifting Star issues fix

### DIFF
--- a/scripts/Avaritia.zs
+++ b/scripts/Avaritia.zs
@@ -141,7 +141,7 @@ import mods.jei.JEI.removeAndHide as rh;
 	[null, null, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, null, null], 
 	[null, null, <ore:dustAstralStarmetal>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>, null, null], 
 	[null, null, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, null], 
-	[null, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:ingotCrystalMatrix>, <extendedcrafting:material:40>, <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
+	[null, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:ingotCrystalMatrix>, <astralsorcery:itemshiftingstar>.withTag({astralsorcery: {}}), <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:ingotCrystalMatrix>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <thaumcraft:triple_meat_treat>, <ore:ingotCosmicNeutronium>, <thaumcraft:triple_meat_treat>, <ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>], 
 	[<ore:dustAstralStarmetal>, <ore:foodPorkrinds>, <thaumcraft:triple_meat_treat>, <ore:foodPorkrinds>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, <ore:dustAstralStarmetal>, null], 

--- a/scripts/Endergy.zs
+++ b/scripts/Endergy.zs
@@ -79,7 +79,7 @@ print("--- loading Endergy.zs ---");
 	mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:benitoite>, 100000000, 1000000, <botania:manaresource:5>, 
 	[<botania:manaresource:9>, <botania:manaresource:1>, <botania:manaresource:7>, 
 	<botania:pylon:1>, <botania:manaresource:2>, <botania:manaresource:8>, 
-	<astralsorcery:itemcraftingcomponent:2>, <extendedcrafting:material:40>, 
+	<astralsorcery:itemcraftingcomponent:2>, <astralsorcery:itemshiftingstar>.withTag({astralsorcery: {}}), 
 	<astralsorcery:itemcraftingcomponent:4>, <astralsorcery:itemcoloredlens:6>, 
 	<bloodmagic:blood_rune:9>, <bloodmagic:blood_rune:10>, <bloodmagic:points_upgrade>,
 	<bloodmagic:slate:4>, <thaumcraft:mechanism_complex>]);

--- a/scripts/ModularMachinery.zs
+++ b/scripts/ModularMachinery.zs
@@ -20,7 +20,7 @@ import mods.jei.JEI.removeAndHide as rh;
 # Starlight Crafting Engine
 	recipes.addShapedMirrored("Starlight Crafting Engine", 
 	<modularmachinery:itemblueprint>.withTag({dynamicmachine: "modularmachinery:starlight_crafting_engine"}), 
-	[[<ore:ingotModularium>, <astralsorcery:itemshiftingstar>, <ore:ingotModularium>],
+	[[<ore:ingotModularium>, <astralsorcery:itemshiftingstar>.withTag({astralsorcery: {}}), <ore:ingotModularium>],
 	[<ore:ingotModularium>, <immersiveengineering:blueprint>.anyDamage(), <ore:ingotModularium>], 
 	[<ore:ingotModularium>, <astralsorcery:itemcraftingcomponent:4>, <ore:ingotModularium>]]);
 

--- a/scripts/modular_machinery/starlight_crafting_engine.zs
+++ b/scripts/modular_machinery/starlight_crafting_engine.zs
@@ -1,7 +1,7 @@
 var machineName = "starlight_crafting_engine";
 
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_shifting_star", machineName, 600)
-	.addItemOutput(<astralsorcery:itemshiftingstar>)
+	.addItemOutput(<astralsorcery:itemshiftingstar>.withTag({astralsorcery: {}}))
 	.addFluidInput(<liquid:astralsorcery.liquidstarlight> * 5000)
 	.addItemInput(<ore:gemAquamarine>, 4)
 	.addItemInput(<ore:dustAstralStarmetal>, 2)
@@ -37,7 +37,7 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_luminous_powder",
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_prism", machineName, 700)
 	.addItemOutput(<astralsorcery:itemenchantmentamulet>)
 	.addFluidInput(<liquid:astralsorcery.liquidstarlight> * 6000)
-	.addItemInput(<astralsorcery:itemshiftingstar>)
+	.addItemInput(<astralsorcery:itemshiftingstar>.withTag({astralsorcery: {}}))
 	.addItemInput(<ore:string>)
 	.addItemInput(<ore:pearlEnderEye>)
 	.addItemInput(<ore:ingotGold>, 2)


### PR DESCRIPTION
Changed the Shifting Star recipe to match a handmade one.

Also changed the recipes that required said Shifting Star to match the new output and handmades.

(Also don't know why DNA and build lines have supposedly changed when they haven't)