### PR TITLE
Change inventory panel recipe to be friendlier to earlygame

### DIFF
--- a/scripts/EnderIO.zs
+++ b/scripts/EnderIO.zs
@@ -53,7 +53,7 @@ craft.remake(<enderio:block_impulse_hopper>, ["pretty",
     recipes.addShaped("Ender IO Inventory Panel", 
     <enderio:block_inventory_panel>,
     [[<enderio:item_alloy_ingot:6>, <enderio:item_material:64>, <enderio:item_alloy_ingot:6>],
-    [<enderio:item_material:14>, <nuclearcraft:part:10>, <enderio:item_material:14>],
+    [<enderio:item_material:14>, <rftools:storage_scanner>, <enderio:item_material:14>],
     [<enderio:item_alloy_ingot:6>, <enderio:block_tank>, <enderio:item_alloy_ingot:6>]]);
 
 # Painting Machine

--- a/scripts/EnderIO.zs
+++ b/scripts/EnderIO.zs
@@ -48,6 +48,14 @@ craft.remake(<enderio:block_impulse_hopper>, ["pretty",
 	[<ore:paper>, <enderio:block_enderman_skull>, <ore:paper>], 
 	[<ore:blockRedstone>, <ore:paper>, <ore:blockRedstone>]]);
 
+    # Inventory Panel
+    recipes.remove(<enderio:block_inventory_panel>);
+    recipes.addShaped("Ender IO Inventory Panel", 
+    <enderio:block_inventory_panel>,
+    [[<enderio:item_alloy_ingot:6>, <enderio:item_material:64>, <enderio:item_alloy_ingot:6>],
+    [<enderio:item_material:14>, <nuclearcraft:part:10>, <enderio:item_material:14>],
+    [<enderio:item_alloy_ingot:6>, <enderio:block_tank>, <enderio:item_alloy_ingot:6>]]);
+
 # Painting Machine
 	recipes.remove(<enderio:block_painter>);
 	recipes.addShaped("Ender IO Painting Machine", <enderio:block_painter>, 


### PR DESCRIPTION
The inventory panel is a way to connect multiple inventories together, similar to the storage scanner. This method is more scalable because adding new storage to the network is as simple as running conduits. It could serve as a potential alternative to early-game item management. 

## Current (1.90g)

As it currently stands, the inventory panel is gated behind Ender IO machine frames. This pushes the availability of the item to well after AE2 is unlocked, making it effectively useless.

## Proposed Change

The change in question modifies the recipe of the inventory panel to make it much more approachable to someone starting their world. It swaps out the ender resonator for a NuclearCraft machine frame, which is significantly cheaper. This does not affect any other elements of Ender IO. 