### PR TITLE
Change Pork Rinds and Cracklins recipes

### DIFF
--- a/scripts/Harvestcraft.zs
+++ b/scripts/Harvestcraft.zs
@@ -4,8 +4,8 @@ import crafttweaker.item.IItemStack;
 oreDict.cropLychee.add(<harvestcraft:lycheeitem>);
 oreDict.cropJackfruit.add(<harvestcraft:jackfruititem>);
 
-recipes.addShapeless(<harvestcraft:cracklinsitem>, [<ore:toolPot>, <ore:listAllporkraw>, <ore:foodOliveoil>, <ore:cropSpiceleaf>]);
-recipes.addShapeless(<harvestcraft:porkrindsitem>, [<ore:toolPot>, <ore:foodSalt>, <ore:foodOliveoil>, <ore:foodBlackpepper>]);
+recipes.addShapeless(<harvestcraft:cracklinsitem>, [<ore:toolPot>, <ore:listAllporkraw>, <ore:foodOliveoil>, <quark:tallow>, <ore:cropSpiceleaf>]);
+recipes.addShapeless(<harvestcraft:porkrindsitem>, [<ore:toolPot>, <ore:foodSalt>, <ore:listAllporkraw>, <ore:foodOliveoil>, <ore:foodBlackpepper>]);
 
 recipes.addShapeless(<harvestcraft:imitationcrabsticksitem>, [<ore:toolCuttingboard>, <ore:foodFlour>, <ore:listAllfishcooked>, <ore:listAllegg>, <minecraft:dye:1>]);
 recipes.addShapeless(<harvestcraft:saucedlambkebabitem>, [<ore:toolMixingbowl>, <ore:foodLambkebab>, <ore:foodPlainyogurt>, <ore:listAllheavycream>, <ore:cropGarlic>, <ore:cropSpiceleaf>, <ore:cropLime>]);


### PR DESCRIPTION
A potential fix to #2180.

Adds raw pork to Pam's Harvestcraft's Pork Rinds, and adds Tallow from Quark to Cracklins to help differentiate the recipe from Pork Rinds and reflecting its alleged nature of having more fat: https://www.allrecipes.com/article/what-are-pork-rinds/