### PR TITLE
Fix error in Rolling Machine quest

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -32415,7 +32415,7 @@
           "ismain:1": 0,
           "repeat_relative:1": 1,
           "name:8": "Rolling Machine",
-          "desc:8": "The Rolling Machine is a multiblock machine that uses RF and Lubricant to make Plates much more efficiently than the Smal Plate Presser.\n\nIts other uses include the ability to craft Sheets of various materials, as well as Pressure Tanks that allow to easily transport higher quantities of fluid than Buckets.\n\nIt is recommended to make this machine early to cut down the metal cost of crafting the various components required by other machines."
+          "desc:8": "The Rolling Machine is a multiblock machine that uses RF and Lubricant to make Plates much more efficiently than the Small Plate Presser.\n\nIts other uses include the ability to craft Sheets of various materials, as well as Pressure Tanks that allow to easily transport higher quantities of fluid than Buckets.\n\nIt is recommended to make this machine early to cut down the metal cost of crafting the various components required by other machines."
         }
       },
       "tasks:9": {

--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -32415,7 +32415,7 @@
           "ismain:1": 0,
           "repeat_relative:1": 1,
           "name:8": "Rolling Machine",
-          "desc:8": "The Rolling Machine is a multiblock machine that uses RF and Water to make Plates much more efficiently than the Smal Plate Presser.\n\nIts other uses include the ability to craft Sheets of various materials, as well as Pressure Tanks that allow to easily transport higher quantities of fluid than Buckets.\n\nIt is recommended to make this machine early to cut down the metal cost of crafting the various components required by other machines."
+          "desc:8": "The Rolling Machine is a multiblock machine that uses RF and Lubricant to make Plates much more efficiently than the Smal Plate Presser.\n\nIts other uses include the ability to craft Sheets of various materials, as well as Pressure Tanks that allow to easily transport higher quantities of fluid than Buckets.\n\nIt is recommended to make this machine early to cut down the metal cost of crafting the various components required by other machines."
         }
       },
       "tasks:9": {


### PR DESCRIPTION
![image](https://github.com/EnigmaticaModpacks/Enigmatica2Expert/assets/66441550/a0b108a8-0750-4ffb-b4ba-4b9eedd2972e)

As shown in the attached image, the Rolling Machine quest entry mentions that it uses water. 
This is however no longer the case, I believe as of 1.86?

There was also a typo, where `Smal` was used instead of `Small`.

This pull request fixes both issues.